### PR TITLE
Feature/pythonic nodes

### DIFF
--- a/FigmaPy/models.py
+++ b/FigmaPy/models.py
@@ -357,6 +357,7 @@ class Text(Vector):
     # A regular n-sided polygon [Shares properties of Vector]
     # plus characters, style, characterStyleOverrides, and styleOverrideTable
     def __init__(self, characters, style, characterStyleOverrides, styleOverrideTable, lineTypes, lineIndentations,
+                 layoutVersion=None,
                  *args, **kwargs):
         self.characters = characters  # Text contained within text box
         self.style = style  # Style of text including font family and weight
@@ -364,6 +365,7 @@ class Text(Vector):
         self.styleOverrideTable = styleOverrideTable  # Map from ID to TypeStyle for looking up style overrides
         self.lineTypes = lineTypes
         self.lineIndentations = lineIndentations
+        self.layoutVersion = layoutVersion  # -> int, not documented in figma API
         super().__init__(*args, **kwargs)
 
 

--- a/FigmaPy/models.py
+++ b/FigmaPy/models.py
@@ -85,6 +85,7 @@ class Node:
             print("Node class has been instantiated with unsupported args and kwargs."
                   "this is likely due to a change in the Figma API, or an unsupported parameter in this wrapper")
             print(args, kwargs)
+            print(self)
 
     def deserialize_properties(self):
         """

--- a/FigmaPy/models.py
+++ b/FigmaPy/models.py
@@ -572,9 +572,9 @@ class Transform:
 
 class FrameOffset:
     # A relative offset within a frame
-    def __init__(self, nodeId, nodeOffset):
+    def __init__(self, node_id, node_offset):
         self.node_id = node_id  # Unique id specifying the frame
-        self.nodeOffset = Vector2d(**nodeOffset)  # 2d vector offset within the frame
+        self.node_offset = Vector2d(**node_offset)  # 2d vector offset within the frame
 
 
 class ColorStop:

--- a/FigmaPy/models.py
+++ b/FigmaPy/models.py
@@ -107,6 +107,10 @@ class Node:
             self.layoutGrids = [LayoutGrid(**grid) for grid in self.layoutGrids]
         if hasattr(self, 'children') and isinstance(self.children, list) and self.children is not None:
             self.children = [self.deserialize(child) for child in self.children]
+        if hasattr(self, 'fillGeometry') and isinstance(self.fillGeometry, list) and self.fillGeometry is not None:
+            self.fillGeometry = [Path(**path) for path in self.fillGeometry]
+        if hasattr(self, 'strokeGeometry') and isinstance(self.strokeGeometry, list) and self.strokeGeometry is not None:
+            self.strokeGeometry = [Path(**path) for path in self.strokeGeometry]
 
     @staticmethod
     def deserialize(node_dict):
@@ -562,12 +566,13 @@ class Transform:
         self.matrix = matrix  # Transformation matrix
 
 
-# seems to be removed from figmaAPI
-# class Path:
-#     # A vector path
-#     def __init__(self, path, winding_rule):
-#         self.path = path  # A sequence of path commands in SVG notation
-#         self.winding_rule = winding_rule  # Winding rule for the path, either 'EVENODD' or 'NONZERO'
+# not documented in the usual figma doc page: https://www.figma.com/developers/api
+# instead see https://www.figma.com/plugin-docs/api/VectorPath/#docsNav
+class Path:
+    # A vector path
+    def __init__(self, path, windingRule):
+        self.path = path  # A sequence of path commands in SVG notation
+        self.windingRule = windingRule  # Winding rule for the path, either 'EVENODD' or 'NONZERO'
 
 
 class FrameOffset:

--- a/FigmaPy/models.py
+++ b/FigmaPy/models.py
@@ -8,6 +8,7 @@ class File:
         self.name = name  # File name
         self.lastModified = lastModified  # Date file was last modified
         self.thumbnailUrl = thumbnailUrl  # File thumbnail URL
+        print('document', document)
         self.document = Document(**document)  # Document content from a file
         self.components = components  # Document components from a file
         self.schemaVersion = schemaVersion  # Schema version from a file
@@ -96,8 +97,8 @@ def serialise_children(children):
     serialised_children = []
     for child in children:
         node_type = NodeTypes[child.get('type')]
-        node_type(**child)
-        serialised_children.append(node_type)
+        node = node_type.value(**child)
+        serialised_children.append(node)
     return serialised_children
 
 
@@ -125,9 +126,10 @@ class Node:
 
 class Document(Node):
     # The root node
-    def __int__(self,
+    def __init__(self,
                 children,
                 *args, **kwargs):
+        print('children', children)
         super().__init__(*args, **kwargs)
         self.children = serialise_children(children)  # An array of canvases attached to the document
 
@@ -145,12 +147,16 @@ class Canvas(Node):
     def __init__(self,
                  children,
                  backgroundColor,
+                 prototypeStartNodeID=None,
+                 prototypeDevice=None,
                  flowStartingPoints=None,
                  exportSettings=None,
                  *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.children = serialise_children(children)  # An array of top level layers on the canvas
         self.backgroundColor = backgroundColor  # Background color of the canvas
+        self.prototypeStartNodeID = prototypeStartNodeID  # DEPRECATED] Node ID that corresponds to the start frame for prototypes. This is deprecated with the introduction of multiple flows. Please use the flowStartingPoints field.
+        self.prototypeDevice = prototypeDevice
         self.flowStartingPoints = flowStartingPoints  # An array of flow starting points sorted by its position in the prototype settings panel.
         self.exportSettings = exportSettings  # An array of export settings representing images to export. Default: []
 
@@ -164,8 +170,9 @@ class Frame(Node):
                  blendMode,
                  constraints,
                  absoluteBoundingBox,
-                 size,
-                 relativeTransform, clipsContent,
+                 clipsContent,
+                 size=None,
+                 relativeTransform=None,
                  locked=False,
                  fills=None,
                  strokes=None,
@@ -222,8 +229,8 @@ class Group(Frame):
 
 class Vector(Node):
     # A vector network, consisting of vertices and edges
-    def __init__(self, blendMode, constraints, absoluteBoundingBox, size, relativeTransform, fillGeometry,
-                 strokeWeight, strokeGeometry, strokeAlign, exportSettings=None, preserveRatio=False,
+    def __init__(self, blendMode, constraints, absoluteBoundingBox, size=None, relativeTransform=None, fillGeometry=None,
+                 strokeWeight=None, strokeGeometry=None, strokeAlign=None, exportSettings=None, preserveRatio=False,
                  transitionNodeID=None, opacity=1, transitionNodeDuration=None,
                  transitionEasing=None, layoutGrow=0, locked=False, layoutAlign=None, effects=None,
                  isMask=False, fills=None,
@@ -298,10 +305,10 @@ class RegularPolygon(Vector):
 
 
 class Rectangle(Vector):
-    # A rectangle [Shares properties of Vector plus corner_radius]
-    def __init__(self, corner_radius, rectangleCornerRadii, *args, **kwargs):
+    # A rectangle [Shares properties of Vector plus cornerRadius]
+    def __init__(self, cornerRadius=None, rectangleCornerRadii=None, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.corner_radius = corner_radius  # Radius of each corner of the rectangle
+        self.cornerRadius = cornerRadius  # Radius of each corner of the rectangle
         self.rectangleCornerRadii = rectangleCornerRadii
 
 

--- a/FigmaPy/models.py
+++ b/FigmaPy/models.py
@@ -126,6 +126,17 @@ class Node:
         node = node_type.value(**node_dict)
         return node
 
+    def get_children_recursively(self):
+        """
+        get all children of this node, recursively.
+        """
+        nodes_found = []
+        for node in self.children:
+            nodes_found.append(node)
+            if hasattr(node, 'children'):
+                node.get_children_recursively()
+        return nodes_found
+
     # @staticmethod
     # def serialize(node):
     #     raise NotImplementedError

--- a/README.md
+++ b/README.md
@@ -7,6 +7,35 @@
 
 An unofficial Python3+ wrapper for Figma API
 
+### Quick start
+
+```python
+import FigmaPy
+import pprint
+
+token = 'REPLACE_WITH_YOUR_TOKEN'  # can be found in your figma user profile page
+file_key = 'REPLACE_WITH_YOUR_FILE_KEY'  # can be found in the URL of the file
+figmaPy = FigmaPy.FigmaPy(token=token)
+file = figmaPy.get_file(file_key=file_key)
+
+print([x.name for x in file.document.children])
+# ['Page 1', 'Page 2']
+
+page1 = file.document.children[0]
+print([x.name for x in page1.children])
+# ['myArrow', 'myGroup', 'myImage']
+
+ids = [x.id for x in page1.children]
+print(ids)
+# ['7:2', '7:6', '21:4']
+
+images = figmaPy.get_file_images(file_key=file_key, ids=ids)
+pprint.pprint(images.images)
+# {'21:4': 'https://figma-alpha-api.s3.us-west-2.amazonaws.com/images/9bc9fdbd-REDACTED-2d1f31e9b57e',
+#  '7:2': 'https://figma-alpha-api.s3.us-west-2.amazonaws.com/images/de2afe63d-REDACTED-8abc-9ca5b5f88ac8',
+#  '7:6': 'https://figma-alpha-api.s3.us-west-2.amazonaws.com/images/f56d5d8dd-REDACTED-af17-461010e0af14'}
+```
+
 ### Install 
 From PyPI:
 ```bash

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 An unofficial Python3+ wrapper for Figma API
 
-### Quick start
+## Quick start
 
 ```python
 import FigmaPy
@@ -35,19 +35,24 @@ pprint.pprint(images.images)
 #  '7:6': 'https://figma-alpha-api.s3.us-west-2.amazonaws.com/images/f56d5d8dd-REDACTED-af17-461010e0af14'}
 ```
 
-### Install
-- From this repo:
-Most up to date code lives here.
+## Install
+##### From Source - most up to date code
 
-- From PyPI: (might be outdated)
+Clone or download the repository, navigate to the root folder and run:
+```bash
+python setup.py install
+```
+
+
+#### From PyPI
 ```bash
 pip install FigmaPy
 ```
-- Using Distributed Wheel from GitHub: (might be outdated)
+#### Using Distributed Wheel from GitHub:
 ```bash
 pip install FigmaPy-2018.1.0-py3-none-any.whl
 ```
 
 
-### Documentation
+## Documentation
 API Documentation : https://www.figma.com/developers/docs

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-![alt text](http://www.iamgregamato.com/img/fp_logo.svg)
 <p align=center>
   <a href="https://badge.fury.io/py/FigmaPy">
     <img src="https://badge.fury.io/py/FigmaPy.svg" alt="PyPI version" height="18">
@@ -36,13 +35,19 @@ pprint.pprint(images.images)
 #  '7:6': 'https://figma-alpha-api.s3.us-west-2.amazonaws.com/images/f56d5d8dd-REDACTED-af17-461010e0af14'}
 ```
 
-### Install 
-From PyPI:
+### Install
+- From this repo:
+Most up to date code lives here.
+
+- From PyPI: (might be outdated)
 ```bash
 pip install FigmaPy
 ```
-Using Distributed Wheel from GitHub:
+- Using Distributed Wheel from GitHub: (might be outdated)
 ```bash
 pip install FigmaPy-2018.1.0-py3-none-any.whl
 ```
+
+
+### Documentation
 API Documentation : https://www.figma.com/developers/docs


### PR DESCRIPTION
This PR makes figmaPy more pythonic:

FigmaPy already had python classes for each nodeType in models.py, 
yet these classes were not used when requesting get_file().
By hooking these classes up to get_file, and serializing each child into it's matching node_type,
working with figma data becomes more pythonic.

so we don't do this anymore
```python
file.document['children']
```
but instead we do
```python
file.document.children
```
----------------
# Other updates

- added quickstart code to [the readme](https://github.com/hannesdelbeke/FigmaPy/blob/feature/refactor_nodes/README.md) showing of the new pythonic classes
- added new properties to various nodetypes
- variable names now follow figma API naming convention instead of PEP8. 
- allowing any dicts from the figma API to be loaded directly into FigmaPy classes. 
example: corner_radius is now cornerRadius

the following new classes are setup but not yet fully implemented
- class Sticky(Node):
- class ShapeWithText(Node):
- class Connector(Node):