### PR TITLE
figma session singleton tracker

### DIFF
--- a/figmapy/datatypes/models.py
+++ b/figmapy/datatypes/models.py
@@ -5,6 +5,7 @@
 from typing import List
 
 from . import nodes
+from figmapy.session import current
 
 
 # -------------------------------------------------------------------------
@@ -79,6 +80,14 @@ class File:
         # python helpers
         # using underscore to mark var as python helper, instead of a figma api var
         self._parent = _parent
+
+    def get_file_images(self, ids, scale=None, format=None, version=None):
+        """syncronously get all images from the file"""
+        return current.figma_session.get_file_images_sync(file_key=self.mainFileKey,
+                                                          ids=ids,
+                                                          scale=scale,
+                                                          format=format,
+                                                          version=version)
 
 
 class Comment:

--- a/figmapy/session/base.py
+++ b/figmapy/session/base.py
@@ -1,5 +1,9 @@
+from figmapy.session import current
+
+
 class FigmaPyBase:
     def __init__(self, token, oauth2=False):
+        current.figma_session = self
         self.api_uri = 'https://api.figma.com/v1/'
         self.token_uri = 'https://www.figma.com/oauth'
         self.api_token = token

--- a/figmapy/session/base.py
+++ b/figmapy/session/base.py
@@ -8,3 +8,8 @@ class FigmaPyBase:
         self.token_uri = 'https://www.figma.com/oauth'
         self.api_token = token
         self.oauth2 = oauth2
+
+    # shared functions between sync and async, used by figma datatypes
+    def get_file_images_sync(self, *args, **kwargs):
+        raise NotImplementedError
+

--- a/figmapy/session/current.py
+++ b/figmapy/session/current.py
@@ -1,0 +1,5 @@
+# to avoid import loops, this is a separate module
+#
+# a helper to allow for easy access to the active session from figma nodes.
+# do not rely on this session when using multiple active sessions.
+figma_session = None

--- a/figmapy/session/figma_aiohttp.py
+++ b/figmapy/session/figma_aiohttp.py
@@ -1,5 +1,6 @@
 try:
     import aiohttp
+    import asyncio
 except ImportError:
     print("Async dependencies have not been installed: [httpx]")
 
@@ -86,3 +87,7 @@ class AioHttpFigmaPy(FigmaPyBase):
         data = await self.async_api_request(api_url, method='get')
         if data is not None:
             return FileImages(data['images'], data['err'])
+
+    # helper functions shared with sync version
+    def get_file_images_sync(self, *args, **kwargs):
+        asyncio.run(self.get_file_images(*args, **kwargs))

--- a/figmapy/session/figma_requests.py
+++ b/figmapy/session/figma_requests.py
@@ -239,3 +239,7 @@ class FigmaPy(FigmaPyBase):
 
         data = self.get_file_images(file_key, ids=vector_ids, scale=scale, format=format)
         return data.images
+
+    # helper functions shared with sync version
+    def get_file_images_sync(self, *args, **kwargs):
+        return self.get_file_images(*args, **kwargs)


### PR DESCRIPTION
track session as singleton in module
this way we can start adding lots of convenient methods to get images. nodes. etc
since we usually init a single figma session, working on a single file
 it's inconvennient to track and parse it all the time.

we now also share a function between sync and async session
get_file_images_sync.