### PR TITLE
chore: bump version 2018.1.0 -> 2026.1.0 + add CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: ["master", "main"]
+  pull_request:
+
+jobs:
+  test:
+    name: "Python ${{ matrix.python-version }}"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "${{ matrix.python-version }}"
+          cache: pip
+
+      - name: Install
+        run: pip install -e ".[dev]"
+
+      - name: Run tests (fast)
+        run: pytest -m "not slow" --tb=short -q
+
+      - name: Run slow tests (generated code staleness check)
+        run: pytest -m slow --tb=short -q
+        # Only run on the main branch push to keep PR feedback fast
+        if: github.event_name == 'push'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
 
-Versions track the Figma OpenAPI spec release they were generated from. See
-[docs/versioning.md](docs/versioning.md).
+Versions use date-based versioning (`YEAR.RELEASE.PATCH`). See
+[docs/versioning.md](docs/versioning.md) for the scheme; `figmapy.FIGMA_SPEC_VERSION`
+tells you which Figma OpenAPI spec each release was generated from.
 
-## 0.42.0
+## 2026.1.0
 
 Generated from [rest-api-spec
 v0.42.0](https://github.com/figma/rest-api-spec/releases/tag/v0.42.0).

--- a/README.md
+++ b/README.md
@@ -136,15 +136,14 @@ but only after you have unblocked yourself with the row above.
 
 ## Versioning
 
-The package version *is* the Figma spec version. `FigmaPy 0.42.0` is generated from
-[`rest-api-spec v0.42.0`](https://github.com/figma/rest-api-spec/releases/tag/v0.42.0).
+The package version follows date-based versioning (`YEAR.RELEASE.PATCH`), continuing the scheme from `FigmaPy 2018.1.0` on PyPI.
 
 ```python
-figmapy.FIGMA_SPEC_VERSION   # '0.42.0'
+figmapy.__version__          # '2026.1.0'
+figmapy.FIGMA_SPEC_VERSION   # '0.42.0' - the Figma OpenAPI spec this was generated from
 ```
 
-Fixes to the hand-written parts ship as `0.42.0.post1` and friends. See
-[docs/versioning.md](docs/versioning.md) for the full rules and what counts as breaking.
+See [docs/versioning.md](docs/versioning.md) for the full rules.
 
 ## Upgrading from 2018.1.0
 

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -67,7 +67,7 @@ one construct — not to move to a heavyweight generator. The places it makes as
 ## Releasing
 
 ```
-git tag v0.42.0 && git push --tags
+git tag v2026.1.0 && git push --tags
 ```
 
 `.github/workflows/release.yml` checks that the tag matches `figmapy.__version__`, runs

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -2,62 +2,65 @@
 
 ## The rule
 
-**The package version is the Figma spec version.**
+**The package version is date-based: `YEAR.RELEASE.PATCH`.**
 
-`FigmaPy 0.42.0` is generated from [`figma/rest-api-spec`
-v0.42.0](https://github.com/figma/rest-api-spec/releases/tag/v0.42.0). Nothing else.
-
-```python
-figmapy.__version__          # '0.42.0'
-figmapy.FIGMA_SPEC_VERSION   # '0.42.0' - always the same string
+```
+2026.1.0    first release of 2026
+2026.1.1    patch fix within that release
+2026.2.0    second release of 2026
+2027.1.0    first release of 2027
 ```
 
-`spec/VERSION` in the repository is the single source of truth. `tools/sync_spec.py`
-writes it, writes the matching number into `pyproject.toml`, and a test fails if the two
-ever disagree.
+This continues the scheme established by `FigmaPy 2018.1.0` on PyPI.
 
-## Why not semver
+```python
+figmapy.__version__          # '2026.1.0'
+figmapy.FIGMA_SPEC_VERSION   # '0.42.0' - the Figma OpenAPI spec this was generated from
+```
 
-Semver answers "will this upgrade break my code?". For a wrapper whose entire surface is
-someone else's API, that question has a better answer: "which version of their API is
-this?". Coupling the two numbers means:
+These two numbers are independent. `FIGMA_SPEC_VERSION` tells you which Figma spec
+the client and models were generated from. `__version__` tells you the package release.
 
-- You can tell at a glance whether your installed version knows about a Figma feature.
-  If Figma's changelog says a field landed in 0.44.0 and you have 0.42.0, you know.
-- There is no judgement call in the release process, so a bot can run it. A human
-  deciding "is this a minor or a patch?" is exactly the step that stalls, and stalling is
-  what left the old PyPI release stranded on 2018.1.0 for seven years.
-- Nobody has to maintain a mapping table between two version schemes.
+## Why date-based
 
-The cost is that a FigmaPy version bump does not tell you whether *your* code breaks. The
-pull request does: every spec sync ships with a generated diff, and anything removed or
-newly required is labelled `breaking`. See [maintenance.md](maintenance.md).
+- Continues the existing `2018.1.0` convention already on PyPI.
+- `YEAR` gives an immediate sense of how recent the release is.
+- No judgement call on major/minor/patch for what is essentially a generated wrapper —
+  breaking changes are detected mechanically by `tools/sync_spec.py` and reported in the
+  PR, not encoded in the version number.
+
+## Figma spec updates
+
+When the Figma spec is updated, `tools/sync_spec.py` bumps `spec/VERSION` and regenerates
+`figmapy/_endpoints.py` and `figmapy/models.py`. The package version in `pyproject.toml`
+is updated separately by the maintainer as part of the release.
+
+```
+spec/VERSION    0.42.0  -> 0.43.0    (written by sync_spec.py)
+pyproject.toml  2026.1.0 -> 2026.2.0  (updated manually before tagging)
+```
 
 ## Fixes that are not spec changes
 
-A bug in the hand-written parts — the client, retries, helpers, errors — ships as a PEP
-440 post-release of whatever spec version is current:
+A bug fix in the hand-written parts ships as a patch bump:
 
 ```
-0.42.0        spec v0.42.0
-0.42.0.post1  same spec, a fix in figmapy/client.py
-0.42.0.post2  same spec, another fix
-0.43.0        spec v0.43.0, and everything in the posts above
+2026.1.0    initial release
+2026.1.1    fix in figmapy/client.py
+2026.2.0    next planned release (may include a new spec version)
 ```
-
-`pip install FigmaPy==0.42.*` gets you the fixes without the spec moving under you.
 
 ## Pinning
 
 | You want | Put this in your requirements |
 | --- | --- |
 | Whatever is newest | `FigmaPy` |
-| A known-good spec version, plus fixes | `FigmaPy==0.42.*` |
-| Byte-for-byte reproducible | `FigmaPy==0.42.0` |
+| A known-good release, plus patches | `FigmaPy==2026.1.*` |
+| Byte-for-byte reproducible | `FigmaPy==2026.1.0` |
 
-Pinning is cheap here, because being behind is not a wall — see the escape hatches in the
-[README](../README.md#nothing-here-should-ever-block-you). An old pin still talks to
-today's Figma; it just has fewer typed conveniences for the newest fields.
+Pinning is cheap here, because being behind is not a wall: an old pin still talks to
+today's Figma; it just has fewer typed conveniences for the newest fields. Use
+`figma.request("GET", "/v1/...")` as an escape hatch for anything not yet wrapped.
 
 ## What counts as breaking
 
@@ -69,10 +72,4 @@ Decided mechanically by `tools/sync_spec.py`, not by taste:
 - a schema disappeared
 
 Everything else — new endpoints, new optional parameters, new fields, description
-changes — is additive. Additive syncs can merge and release without a human. Breaking
-ones cannot.
-
-## Zero major version
-
-The package stays on `0.x` for as long as Figma's spec does. When Figma tags `1.0.0`, so
-does this.
+changes — is additive. See [maintenance.md](maintenance.md).

--- a/figmapy/__init__.py
+++ b/figmapy/__init__.py
@@ -3,7 +3,7 @@
 The client surface and every response model are generated from Figma's official
 OpenAPI spec (https://github.com/figma/rest-api-spec), so this package tracks the API
 instead of chasing it. ``figmapy.FIGMA_SPEC_VERSION`` tells you which spec release you
-have; the package version is the same number.
+have; ``figmapy.__version__`` follows date-based versioning (YEAR.RELEASE.PATCH).
 
     import figmapy
 
@@ -38,7 +38,11 @@ from .helpers import (
     walk,
 )
 
-__version__ = FIGMA_SPEC_VERSION
+try:
+    from importlib.metadata import version as _pkg_version
+    __version__ = _pkg_version("FigmaPy")
+except Exception:
+    __version__ = "2026.1.0"  # fallback when not installed
 __license__ = "Apache-2.0"
 
 #: Pre-1.0 name for :class:`Figma`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,9 +4,9 @@ build-backend = "hatchling.build"
 
 [project]
 name = "FigmaPy"
-# Same number as the Figma OpenAPI spec release this was generated from.
+# Date-based versioning: YEAR.RELEASE.PATCH (e.g. 2026.1.0).
 # See docs/versioning.md.
-version = "0.42.0"
+version = "2026.1.0"
 description = "An unofficial Python wrapper for the Figma REST API, generated from Figma's official OpenAPI spec"
 readme = "README.md"
 license = "Apache-2.0"

--- a/tests/test_generated.py
+++ b/tests/test_generated.py
@@ -8,6 +8,7 @@ one of these fails.
 from __future__ import annotations
 
 import inspect
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -59,7 +60,8 @@ def test_every_async_method_is_a_coroutine():
 def test_package_version_matches_the_pinned_spec():
     pinned = (ROOT / "spec" / "VERSION").read_text(encoding="utf8").strip()
     assert figmapy.FIGMA_SPEC_VERSION == pinned
-    assert figmapy.__version__.startswith(pinned)
+    # Package version is date-based (YEAR.RELEASE.PATCH), independent of spec version.
+    assert re.match(r"^\d{4}\.\d+\.\d+", figmapy.__version__), figmapy.__version__
 
 
 def test_models_accept_unknown_fields():

--- a/tools/sync_spec.py
+++ b/tools/sync_spec.py
@@ -186,7 +186,8 @@ def sync(version: str) -> bool:
 
     SPEC_FILE.write_bytes(new_bytes)
     VERSION_FILE.write_text(f"{version}\n", encoding="utf8")
-    set_project_version(version)
+    # Note: package version (pyproject.toml) is date-based and managed separately.
+    # Only FIGMA_SPEC_VERSION (baked into _endpoints.py) tracks the spec version.
     subprocess.run([sys.executable, str(ROOT / "tools" / "generate.py")], check=True)
 
     REPORT_FILE.parent.mkdir(exist_ok=True)


### PR DESCRIPTION
Two housekeeping changes following the merge of PR #23:

**1. Switch to date-based versioning (2026.1.0)**

- Sets \pyproject.toml\ version to \2026.1.0\, continuing the existing \YEAR.RELEASE.PATCH\ date-based versioning scheme established by \2018.1.0\ on PyPI.
- Decouples \__version__\ (package release) from \FIGMA_SPEC_VERSION\ (\