### PR TITLE
docs: restore PyPI version badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # FigmaPy
 
+[![PyPI version](https://badge.fury.io/py/FigmaPy.svg)](https://badge.fury.io/py/FigmaPy)
+
 An unofficial Python wrapper for the [Figma REST API](https://www.figma.com/developers/api).
 
 Every endpoint and every response model is generated from [Figma's official OpenAPI


### PR DESCRIPTION
Restores the PyPI version badge to the top of README.md.